### PR TITLE
Free from lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,6 @@ dependencies {
     implementation group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.6.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'net.jodah:typetools:0.6.1'
-    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.1'
 }

--- a/src/main/java/com/aaaccell/fixer/request/AuthenticatedRequest.java
+++ b/src/main/java/com/aaaccell/fixer/request/AuthenticatedRequest.java
@@ -2,12 +2,11 @@ package com.aaaccell.fixer.request;
 
 import com.aaaccell.fixer.FixerService;
 import com.aaaccell.fixer.response.Response;
-import lombok.EqualsAndHashCode;
 
-@EqualsAndHashCode(callSuper = false)
+import java.util.Objects;
+
 public abstract class AuthenticatedRequest<T extends Response> extends Request<T> {
 
-    @EqualsAndHashCode.Exclude
     FixerService fixerService;
 
     String accessKey;
@@ -15,6 +14,19 @@ public abstract class AuthenticatedRequest<T extends Response> extends Request<T
     AuthenticatedRequest(FixerService fixerService, String accessKey) {
         this.fixerService = fixerService;
         this.accessKey = accessKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticatedRequest<?> that = (AuthenticatedRequest<?>) o;
+        return Objects.equals(accessKey, that.accessKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accessKey);
     }
 
     public String getAccessKey() {

--- a/src/main/java/com/aaaccell/fixer/request/ConvertRequest.java
+++ b/src/main/java/com/aaaccell/fixer/request/ConvertRequest.java
@@ -2,13 +2,12 @@ package com.aaaccell.fixer.request;
 
 import com.aaaccell.fixer.FixerService;
 import com.aaaccell.fixer.response.ConvertResponse;
-import lombok.EqualsAndHashCode;
 import retrofit2.Call;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class ConvertRequest extends AuthenticatedRequest<ConvertResponse> {
 
     private String from;
@@ -18,6 +17,23 @@ public class ConvertRequest extends AuthenticatedRequest<ConvertResponse> {
 
     public ConvertRequest(FixerService fixerService, String accessKey) {
         super(fixerService, accessKey);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ConvertRequest that = (ConvertRequest) o;
+        return Objects.equals(from, that.from) &&
+                Objects.equals(to, that.to) &&
+                Objects.equals(amount, that.amount) &&
+                Objects.equals(date, that.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), from, to, amount, date);
     }
 
     @Override

--- a/src/main/java/com/aaaccell/fixer/request/SymbolsRequest.java
+++ b/src/main/java/com/aaaccell/fixer/request/SymbolsRequest.java
@@ -2,10 +2,8 @@ package com.aaaccell.fixer.request;
 
 import com.aaaccell.fixer.FixerService;
 import com.aaaccell.fixer.response.SymbolsResponse;
-import lombok.EqualsAndHashCode;
 import retrofit2.Call;
 
-@EqualsAndHashCode(callSuper = true)
 public class SymbolsRequest extends AuthenticatedRequest<SymbolsResponse> {
 
     public SymbolsRequest(FixerService fixerService, String accessKey) {

--- a/src/main/java/com/aaaccell/fixer/request/TimeSeriesRequest.java
+++ b/src/main/java/com/aaaccell/fixer/request/TimeSeriesRequest.java
@@ -3,7 +3,6 @@ package com.aaaccell.fixer.request;
 import com.aaaccell.fixer.FixerService;
 import com.aaaccell.fixer.response.TimeSeriesResponse;
 import com.aaaccell.fixer.util.LocalDateHelper;
-import lombok.EqualsAndHashCode;
 import retrofit2.Call;
 
 import java.io.IOException;
@@ -16,7 +15,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-@EqualsAndHashCode(callSuper = true)
 public class TimeSeriesRequest extends AuthenticatedRequest<TimeSeriesResponse> {
 
     private static final long MAX_TIME_FRAME = 365;
@@ -31,13 +29,30 @@ public class TimeSeriesRequest extends AuthenticatedRequest<TimeSeriesResponse> 
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        TimeSeriesRequest that = (TimeSeriesRequest) o;
+        return Objects.equals(startDate, that.startDate) &&
+                Objects.equals(endDate, that.endDate) &&
+                Objects.equals(base, that.base) &&
+                Objects.equals(symbols, that.symbols);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), startDate, endDate, base, symbols);
+    }
+
+    @Override
     Call<TimeSeriesResponse> getCall() {
         return fixerService.getTimeSeries(accessKey, startDate, endDate, base, symbols);
     }
 
     /**
      * Calls Time-Series Endpoint
-     *
+     * <p>
      * If the given start and end dates overcome the maximum time frame of 365 days (see https://fixer.io/documentation),
      * then the execution of the calls are segmented and their results (e.g. rates) combined to a single response.
      *

--- a/src/main/java/com/aaaccell/fixer/response/ConvertResponse.java
+++ b/src/main/java/com/aaaccell/fixer/response/ConvertResponse.java
@@ -1,13 +1,10 @@
 package com.aaaccell.fixer.response;
 
-import lombok.EqualsAndHashCode;
-
 import java.math.BigDecimal;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class ConvertResponse extends Response {
 
-    @EqualsAndHashCode
     public class Query {
         private String from;
         private String to;
@@ -38,10 +35,23 @@ public class ConvertResponse extends Response {
         }
     }
 
-    @EqualsAndHashCode
     public class Info {
         private Integer timestamp;
         private BigDecimal rate;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Info info = (Info) o;
+            return Objects.equals(timestamp, info.timestamp) &&
+                    Objects.equals(rate, info.rate);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(timestamp, rate);
+        }
     }
 
     private Query query;
@@ -57,6 +67,24 @@ public class ConvertResponse extends Response {
         this.date = date;
         this.historical = historical;
         this.result = result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ConvertResponse that = (ConvertResponse) o;
+        return historical == that.historical &&
+                Objects.equals(query, that.query) &&
+                Objects.equals(info, that.info) &&
+                Objects.equals(date, that.date) &&
+                Objects.equals(result, that.result);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), query, info, date, historical, result);
     }
 
     public Query getQuery() {

--- a/src/main/java/com/aaaccell/fixer/response/ErrorResponse.java
+++ b/src/main/java/com/aaaccell/fixer/response/ErrorResponse.java
@@ -1,8 +1,7 @@
 package com.aaaccell.fixer.response;
 
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class ErrorResponse extends Response {
 
     public class Error {
@@ -14,6 +13,21 @@ public class ErrorResponse extends Response {
             this.code = code;
             this.type = type;
             this.info = info;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Error error = (Error) o;
+            return Objects.equals(code, error.code) &&
+                    Objects.equals(type, error.type) &&
+                    Objects.equals(info, error.info);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(code, type, info);
         }
 
         public Integer getCode() {
@@ -44,6 +58,19 @@ public class ErrorResponse extends Response {
         super(success);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ErrorResponse that = (ErrorResponse) o;
+        return Objects.equals(error, that.error);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), error);
+    }
 
     public Error getError() {
         return error;

--- a/src/main/java/com/aaaccell/fixer/response/Response.java
+++ b/src/main/java/com/aaaccell/fixer/response/Response.java
@@ -1,13 +1,25 @@
 package com.aaaccell.fixer.response;
 
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode
 abstract public class Response {
     private boolean success;
 
     Response(boolean success) {
         this.success = success;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Response response = (Response) o;
+        return success == response.success;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(success);
     }
 
     public boolean isSuccess() {

--- a/src/main/java/com/aaaccell/fixer/response/SymbolsResponse.java
+++ b/src/main/java/com/aaaccell/fixer/response/SymbolsResponse.java
@@ -1,17 +1,29 @@
 package com.aaaccell.fixer.response;
 
-import lombok.EqualsAndHashCode;
-
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class SymbolsResponse extends Response {
     private LinkedHashMap<String, String> symbols;
 
     public SymbolsResponse(boolean success, LinkedHashMap<String, String> symbols) {
         super(success);
         this.symbols = symbols;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        SymbolsResponse that = (SymbolsResponse) o;
+        return Objects.equals(symbols, that.symbols);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), symbols);
     }
 
     public HashMap<String, String> getSymbols() {

--- a/src/main/java/com/aaaccell/fixer/response/TimeSeriesResponse.java
+++ b/src/main/java/com/aaaccell/fixer/response/TimeSeriesResponse.java
@@ -1,13 +1,11 @@
 package com.aaaccell.fixer.response;
 
-import lombok.EqualsAndHashCode;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class TimeSeriesResponse extends Response {
 
     private boolean timeseries;
@@ -30,6 +28,24 @@ public class TimeSeriesResponse extends Response {
         this.endDate = endDate;
         this.base = base;
         this.rates = rates;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        TimeSeriesResponse that = (TimeSeriesResponse) o;
+        return timeseries == that.timeseries &&
+                Objects.equals(startDate, that.startDate) &&
+                Objects.equals(endDate, that.endDate) &&
+                Objects.equals(base, that.base) &&
+                Objects.equals(rates, that.rates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), timeseries, startDate, endDate, base, rates);
     }
 
     public boolean isTimeseries() {

--- a/src/test/java/com/aaaccell/fixer/request/ConvertRequestTest.java
+++ b/src/test/java/com/aaaccell/fixer/request/ConvertRequestTest.java
@@ -1,0 +1,32 @@
+package com.aaaccell.fixer.request;
+
+import com.aaaccell.fixer.Fixer;
+import com.aaaccell.fixer.FixerRequestBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+class ConvertRequestTest {
+
+    private final FixerRequestBuilder builder = Fixer.builder("key");
+
+    @Test
+    void requestEquals() {
+        Assertions.assertEquals(
+                builder
+                        .convert()
+                        .fromCurrency("USD")
+                        .toCurrency("CHF")
+                        .withAmount(BigDecimal.ONE)
+                        .withDate(LocalDateTime.now().toLocalDate()),
+                builder
+                        .convert()
+                        .fromCurrency("USD")
+                        .toCurrency("CHF")
+                        .withAmount(BigDecimal.ONE)
+                        .withDate(LocalDateTime.now().toLocalDate())
+        );
+    }
+}

--- a/src/test/java/com/aaaccell/fixer/request/SymbolsRequestTest.java
+++ b/src/test/java/com/aaaccell/fixer/request/SymbolsRequestTest.java
@@ -1,0 +1,16 @@
+package com.aaaccell.fixer.request;
+
+import com.aaaccell.fixer.Fixer;
+import com.aaaccell.fixer.FixerRequestBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SymbolsRequestTest {
+
+    private final FixerRequestBuilder builder = Fixer.builder("key");
+
+    @Test
+    void requestEquals() {
+        Assertions.assertEquals(builder.symbols(), builder.symbols());
+    }
+}

--- a/src/test/java/com/aaaccell/fixer/response/SymbolsResponseTest.java
+++ b/src/test/java/com/aaaccell/fixer/response/SymbolsResponseTest.java
@@ -1,0 +1,22 @@
+package com.aaaccell.fixer.response;
+
+import com.aaaccell.fixer.Fixer;
+import com.aaaccell.fixer.FixerRequestBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class SymbolsResponseTest {
+
+    private final FixerRequestBuilder builder = Fixer.builder("key");
+
+    @Test
+    void requestEquals() {
+        Assertions.assertEquals(
+                new SymbolsResponse(true, new LinkedHashMap<>(Map.of("key", "value"))),
+                new SymbolsResponse(true, new LinkedHashMap<>(Map.of("key", "value")))
+        );
+    }
+}


### PR DESCRIPTION
Turns out lombok introduce issues (https://github.com/aaaccell/fixer/issues/1) when using fixer as a library. An immediate fix is to provide traditional implementations of `equals` and `hashcode`.